### PR TITLE
Read the data about the latest MARs from pulse

### DIFF
--- a/funsize/worker.py
+++ b/funsize/worker.py
@@ -201,7 +201,7 @@ class FunsizeWorker(ConsumerMixin):
             if submitted_releases >= partial_limit:
                 log.debug(
                     "Already submitted {} jobs, ignoring most recent release.".format(partial_limit))
-                continue
+                break
             for n, chunk in enumerate(chunked(locales, per_chunk), start=1):
                 extra = []
                 for locale in chunk:


### PR DESCRIPTION
Don't query balrog for the latest MAR information, as we now get that directly in the message that triggers the worker.