### PR TITLE
Bug 1186297 cleanup - remove ash from funsize config

### DIFF
--- a/funsize/worker.py
+++ b/funsize/worker.py
@@ -20,7 +20,7 @@ from funsize.utils import properties_to_dict, revision_to_revision_hash, \
 log = logging.getLogger(__name__)
 
 # TODO: move these to config
-PRODUCTION_BRANCHES = ['mozilla-central', 'mozilla-aurora', 'ash', 'oak']
+PRODUCTION_BRANCHES = ['mozilla-central', 'mozilla-aurora', 'oak']
 STAGING_BRANCHES = []
 PLATFORMS = ['linux', 'linux64', 'win32', 'win64', 'macosx64']
 BUILDERS = [


### PR DESCRIPTION
This is a left over from https://bugzilla.mozilla.org/show_bug.cgi?id=1186297. Ash ownership has moved on to other devs and nightlies are no longer enabled there. 

I don't think we specifically need a push to deploy it, just whenever the next one comes along is fine.