### PR TITLE
I'd missed a name change from appName->product

### DIFF
--- a/funsize/worker.py
+++ b/funsize/worker.py
@@ -96,7 +96,7 @@ def parse_taskcluster_message(payload):
     balrog_props = queue.getLatestArtifact(previous_task, props_name)
     log.debug("balrog_props.json: %s", balrog_props)
     try:
-        graph_data['appName'] = balrog_props['properties']['appName']
+        graph_data['product'] = balrog_props['properties']['appName']
         graph_data['platform'] = balrog_props['properties']['platform']
         graph_data['branch'] = balrog_props['properties']['branch']
     except KeyError as excp:
@@ -342,7 +342,7 @@ class FunsizeWorker(ConsumerMixin):
             return
 
         self.create_partials(
-            product=gdata["appName"],
+            product=gdata["product"],
             branch=gdata["branch"],
             platform=gdata["platform"],
             locales=gdata['locales'],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="funsize",
-    version="0.64",
+    version="0.65",
     description="Funsize Scheduler",
     author="Mozilla Release Engineering",
     packages=["funsize"],


### PR DESCRIPTION

Fix an issue where `appName` field is renamed to `product` inconsistently.