### PR TITLE
migration of date branch to mozilla-central

### DIFF
--- a/funsize/worker.py
+++ b/funsize/worker.py
@@ -279,7 +279,7 @@ class FunsizeWorker(ConsumerMixin):
         return [
             u'route.index.project.releng.funsize.date.level-3',
             u'route.index.project.releng.funsize.level-3.date',
-
+            u'route.index.project.releng.funsize.level-3.mozilla-central',
         ]
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="funsize",
-    version="0.66",
+    version="0.67",
     description="Funsize Scheduler",
     author="Mozilla Release Engineering",
     packages=["funsize"],


### PR DESCRIPTION
tc-nightly tier 1 migration needs a new route once it moves to mozilla-central