### PR TITLE
bug 1348844 non-index routes in taskcluster

### DIFF
--- a/funsize/worker.py
+++ b/funsize/worker.py
@@ -292,6 +292,8 @@ class FunsizeWorker(ConsumerMixin):
         return [
             u'route.index.project.releng.funsize.level-3.mozilla-central',
             u'route.index.project.releng.funsize.level-3.mozilla-aurora',
+            u'route.project.releng.funsize.level-3.mozilla-central',
+            u'route.project.releng.funsize.level-3.mozilla-aurora',
         ]
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="funsize",
-    version="0.74",
+    version="0.75",
     description="Funsize Scheduler",
     author="Mozilla Release Engineering",
     packages=["funsize"],


### PR DESCRIPTION
index.* will soon be handled differently, so need to ensure funsize listens to
non-index routes for the same data.