### PR TITLE
Bug 1381268 fix mac en-us partials

### DIFF
--- a/funsize/worker.py
+++ b/funsize/worker.py
@@ -138,7 +138,12 @@ def parse_taskcluster_message(payload):
         # is valid before continuing, but the builds produce
         # some that aren't listed in locales.locale_alias, such
         # as 'ast'  ('ast_es' is present in the library)
+
+        # Linux path
         if artifact['name'] == 'public/build/update/target.complete.mar':
+            mar_locale = 'en-US'
+        elif artifact['name'] == 'public/build/target.complete.mar':
+            # macosx64 en-US repackage artifact path
             mar_locale = 'en-US'
         else:
             try:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="funsize",
-    version="0.82",
+    version="0.83",
     description="Funsize Scheduler",
     author="Mozilla Release Engineering",
     packages=["funsize"],


### PR DESCRIPTION
Linux build-signing has an artifact path of `public/build/update/target.complete.mar`, and the locales had `public/build/<locale>/target.complete.mar`. We were checking for `update`, but macosx64 repackage for en-US didn't have a locale, or the `update`, so we were parsing `build` as the locale, causing downstream failures.