### PR TITLE
bug 1379197 fix insufficient history errors.

### DIFF
--- a/funsize/worker.py
+++ b/funsize/worker.py
@@ -437,6 +437,7 @@ class FunsizeWorker(ConsumerMixin):
                 log.debug("Build %s/%s/%s not found: %s",
                           release, platform, locale, excp)
                 continue
+        return builds
 
     def create_partials(self, product, branch, platform, locales, revision,
                         mar_urls, mar_signing_format, chunk_name=1):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="funsize",
-    version="0.83",
+    version="0.84",
     description="Funsize Scheduler",
     author="Mozilla Release Engineering",
     packages=["funsize"],


### PR DESCRIPTION
Previous version was falling through to the end of the function, and
so implicitly returning None, if there weren't enough historical
releases to build partials from