### PR TITLE
Update funsize scheduler for public balrog api

### DIFF
--- a/funsize/balrog.py
+++ b/funsize/balrog.py
@@ -28,9 +28,13 @@ def _retry_on_http_errors(url, auth, verify, params, errors):
 
 class BalrogClient(object):
 
-    def __init__(self, api_root, auth, cert=None):
+    def __init__(self, api_root, auth=None, cert=None):
         self.api_root = api_root
-        self.auth = auth
+        if auth:
+            self.auth = auth
+        else:
+            self.auth = (None, None)
+
         if cert:
             self.verify = cert
         else:

--- a/funsize/scheduler.py
+++ b/funsize/scheduler.py
@@ -33,8 +33,8 @@ def main():
     balrog_worker_api_root = os.environ.get(
         "BALROG_WORKER_API_ROOT", config["balrog"]["worker_api_root"])
     auth = (
-        os.environ.get("BALROG_USERNAME", config["balrog"]["username"]),
-        os.environ.get("BALROG_PASSWORD", config["balrog"]["password"]),
+        os.environ.get("BALROG_USERNAME", config["balrog"].get("username")),
+        os.environ.get("BALROG_PASSWORD", config["balrog"].get("password")),
     )
     pulse_user = os.environ.get("PULSE_USERNAME", config["pulse"]["user"])
     pulse_password = os.environ.get("PULSE_PASSWORD",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="funsize",
-    version="0.87",
+    version="0.88",
     description="Funsize Scheduler",
     author="Mozilla Release Engineering",
     packages=["funsize"],


### PR DESCRIPTION
This change will allow us to use the public balrog
API, that doesn't require credentials, and so remove
one dependent secret from the config.

It'll also be the same api that funsize uses when the
scheduler is rolled into the task graph generation.

`requests.get` will be fine with `auth=(None, None)`. I've tested this against the public balrog api and the data returned is sane. 