### PR TITLE
Bug 1384938 - Add Treeherder group name to yml task definition

### DIFF
--- a/funsize/tasks/funsize.yml
+++ b/funsize/tasks/funsize.yml
@@ -109,6 +109,7 @@ tasks:
         treeherder:
           symbol: {{ locale_desc }}
           groupSymbol: fs-s-{{ update_number }}
+          groupName: "Funsize partial signing"
           collection:
             opt: true
           machine:
@@ -146,6 +147,7 @@ tasks:
         treeherder:
           symbol: {{ locale_desc }}
           groupSymbol: fs-u-{{ update_number }}
+          groupName: "Funsize partial balrog updates"
           collection:
             opt: true
           machine:

--- a/funsize/tasks/funsize.yml
+++ b/funsize/tasks/funsize.yml
@@ -50,6 +50,7 @@ tasks:
         treeherder:
           symbol: {{ locale_desc }}
           groupSymbol: fs-g-{{ update_number }}
+          groupName: "Funsize partial MAR on demand"
           collection:
             opt: true
           machine:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="funsize",
-    version="0.92",
+    version="0.93",
     description="Funsize Scheduler",
     author="Mozilla Release Engineering",
     packages=["funsize"],


### PR DESCRIPTION
This should fix Bugzilla bug [1384938](https://bugzilla.mozilla.org/show_bug.cgi?id=1384938).

This is a one liner and I haven't run it though Funsize tests.py but I think it should be fine. With this change Treeherder should be able to pick up the right json entry and populate the Funsize group name tooltip in the Treeherder UI.

If the wording needs to be tweaked, or a Tier needs to be added let me know or feel free to alter it during the merge.